### PR TITLE
Update options and usage of find/replace command

### DIFF
--- a/.github/workflows/deploy-portal.yaml
+++ b/.github/workflows/deploy-portal.yaml
@@ -55,6 +55,7 @@ jobs:
           cd sk-portal
           tar -xf build.tar.gz
           rm build.tar.gz
-          #Replace the api endpoint url with the correct one for the environment
-          find . -type f -exec sed -i 's/skdevapi/idva-api-${{ steps.cf-setup.outputs.target-environment }}/g' {} +
+          # Execute a sed command on all files in the 'build' directory to
+          # replace the api endpoint url with the correct one for the environment
+          find ./build -type f -execdir sed -i 's/skdevapi/idva-api-${{ steps.cf-setup.outputs.target-environment }}/g' '{}' +
           cf push --var ENVIRONMENT_NAME=${{ steps.cf-setup.outputs.target-environment }} --strategy rolling


### PR DESCRIPTION
In order to prevent some potential security concerns when performing the
find/replace on the api string within the build directory. The -exec
flag has some known security issues that are outlined in the "find" man
page, and are resolved by using the -execdir flag. Additionally,
providing single-quotes around the {} notation prevents shell expansion
of file names.
