### PR TITLE
add public route

### DIFF
--- a/sk-portal/manifest.yml
+++ b/sk-portal/manifest.yml
@@ -3,6 +3,6 @@ version: 1
 applications:
   - name: sk-portal
     routes:
-      - route: identity-idva-sk-portal-((ENVIRONMENT_NAME)).apps.internal
+      - route: idva-portal-((ENVIRONMENT_NAME)).app.cloud.gov
     memory: 64M
     instances: 2

--- a/sk-sdk/manifest.yml
+++ b/sk-sdk/manifest.yml
@@ -3,6 +3,6 @@ version: 1
 applications:
   - name: sk-sdk
     routes:
-      - route: identity-idva-sk-sdk-((ENVIRONMENT_NAME)).apps.internal
+      - route: idva-sdk-((ENVIRONMENT_NAME)).app.cloud.gov
     memory: 64M
     instances: 2


### PR DESCRIPTION
- Change sk-portal to public route
- Change sk-sdk to public route

In order to enable encryption by default to the static assets that are being served
from Staticfile buildpacks, we can simply change the sk-portal and sk-sdk apps
to use public domains. This has multiple effects:
- TLS is used to connect to the cf app using the cloud.gov load balancers
- Kong does not need to serve requests for static assets as they can be served directly by the apps
- Less network hops to get to static assets leads to faster response times