### PR TITLE
Update install script to not pull hash from s3

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -94,7 +94,7 @@ runs:
       run: |
         app_version=$(cat ${{ inputs.app-directory }}/version)
         full_s3_url="${{ inputs.s3-url }}/$app_version"
-        aws s3 sync --only-show-errors "$full_s3_url" ${{ inputs.app-directory }}
+        aws s3 sync --only-show-errors --exclude "hash" "$full_s3_url" ${{ inputs.app-directory }}
 
     - name: Validate downloaded binary
       shell: bash


### PR DESCRIPTION
The sk setup script should not pull the hash from s3 but instead rely on the hash committed to the repo.