### PR TITLE
removet usps network policy from http

### DIFF
--- a/.github/workflows/deploy-http.yaml
+++ b/.github/workflows/deploy-http.yaml
@@ -65,6 +65,3 @@ jobs:
           app-directory: "sk-http"
           sk-secrets: ${{ secrets[env.SK_SECRETS] }}
           standard-deployment: "true"
-
-      - name: Apply CF Network Policies
-        run: cf add-network-policy sk-http usps


### PR DESCRIPTION
Removing usps from the main branch to create release because it is not read for deployment