### PR TITLE
Explicitly specify security-specific settings

### DIFF
--- a/sk-portal/Staticfile
+++ b/sk-portal/Staticfile
@@ -1,3 +1,8 @@
 root: build
+force_https: true
+host_dot_files: false
+http_strict_transport_security: true
+http_strict_transport_security_include_subdomains: true
+http_strict_transport_security_preload: true
 status_codes:
   404: /index.html

--- a/sk-sdk/Staticfile
+++ b/sk-sdk/Staticfile
@@ -1,0 +1,5 @@
+force_https: true
+host_dot_files: false
+http_strict_transport_security: true
+http_strict_transport_security_include_subdomains: true
+http_strict_transport_security_preload: true


### PR DESCRIPTION
In order to avoid ambiguity with regard to the security settings of the
Staticfile buildpack, explicitly give them values. Specifically, the
"include_subdomains" and "preload" HSTS settings appear to default to
"true" when in reality they do not.
