### PR TITLE
add idva-partners as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+## code changes will send PR to following users
+* @18F/idva-partners


### PR DESCRIPTION
A CODEOWNERS [1] file specifies the owners of files on the branch it it located on. This adds those users or teams as reviewers on PRs. This PR adds @18F/idva-partners as the code owners of this repo.

[1] https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
