### PR TITLE
increase api memory to fix crash due to oom. 

### DIFF
--- a/sk-api/manifest.yml
+++ b/sk-api/manifest.yml
@@ -2,7 +2,7 @@
 version: 1
 applications:
   - name: sk-api
-    memory: 512M
+    memory: 1G
     instances: 2
     buildpacks:
       - nginx_buildpack


### PR DESCRIPTION
in later versions api caches more data, and thus needs more memory