### PR TITLE
Add elasticserach service to analytics connector

### DIFF
--- a/.github/workflows/deploy-analytics.yaml
+++ b/.github/workflows/deploy-analytics.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           require-redis: "true"
           require-postgres: "true"
+          require-elasticsearch: "true"
           s3-url: "s3://com.singularkey.gsa/dev/microservice-analytics"
           app-directory: "sk-analytics"
           sk-secrets: ${{ secrets[env.SK_SECRETS] }}

--- a/sk-analytics/manifest.yml
+++ b/sk-analytics/manifest.yml
@@ -12,5 +12,6 @@ applications:
     services:
       - sk-redis
       - sk-postgres
+      - sk-elasticsearch
     env:
       SK_SECRETS: ((SK_SECRETS))


### PR DESCRIPTION
The analytics connector talks to elasticsearch directly, not through events, so it needs the service binding for es.