### PR TITLE
Improve deployment of node apps

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -119,6 +119,10 @@ runs:
           echo "$SK_SECRETS" | sed 's/^/  /'
         } > ${{ inputs.app-directory }}/vars.yaml
 
+    - name: Copy common files
+      shell: bash
+      run: cp -an common/. ${{ inputs.app-directory }}/
+
     - name: Perform Standard Deployment
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: false
 
   create-required-services:
-    description: 'Boolean indicating whether required services should be created if they dont yet exist.'
+    description: 'Boolean indicating whether required services should be created if they do not yet exist.'
     required: false
     default: false
 

--- a/.github/workflows/deploy-ALL-base.yaml
+++ b/.github/workflows/deploy-ALL-base.yaml
@@ -13,127 +13,47 @@ on:
 
 jobs:
   run-esconfigs:
-    uses: 18F/identity-idva-orchestration/.github/workflows/run-esconfigs.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/run-esconfigs.yaml
+    secrets: inherit
   
   run-dbconfigs:
-    uses: 18F/identity-idva-orchestration/.github/workflows/run-dbconfigs.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/run-dbconfigs.yaml
+    secrets: inherit
   
   run-manifest:
     needs: run-dbconfigs
-    uses: 18F/identity-idva-orchestration/.github/workflows/run-manifest.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/run-manifest.yaml
+    secrets: inherit
 
   deploy-api:
     needs: run-manifest
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-api.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-api.yaml
+    secrets: inherit
 
   deploy-events:
     needs: [run-manifest, run-esconfigs]
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-events.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-events.yaml
+    secrets: inherit
 
   deploy-events-read:
     needs: [run-manifest, run-esconfigs]
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-events-read.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-events-read.yaml
+    secrets: inherit
 
   deploy-analytics:
     needs: [run-manifest, run-esconfigs]
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-analytics.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-analytics.yaml
+    secrets: inherit
 
   deploy-oe:
     needs: run-manifest
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-oe.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-oe.yaml
+    secrets: inherit
 
   deploy-portal:
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-portal.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-portal.yaml
+    secrets: inherit
 
   deploy-sdk:
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-sdk.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-sdk.yaml
+    secrets: inherit

--- a/.github/workflows/deploy-ALL-connectors-0.yaml
+++ b/.github/workflows/deploy-ALL-connectors-0.yaml
@@ -25,130 +25,50 @@ jobs:
 
   deploy-authenticid:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-authenticid.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-authenticid.yaml
+    secrets: inherit
 
   deploy-challenge:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-challenge.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-challenge.yaml
+    secrets: inherit
 
   deploy-credential:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-credential.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-credential.yaml
+    secrets: inherit
 
   deploy-devicepolicy:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-devicepolicy.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-devicepolicy.yaml
+    secrets: inherit
 
   deploy-ews:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-ews.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-ews.yaml
+    secrets: inherit
 
   deploy-fido:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-fido.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-fido.yaml
+    secrets: inherit
 
   deploy-flow:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-flow.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-flow.yaml
+    secrets: inherit
 
   deploy-functions:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-functions.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-functions.yaml
+    secrets: inherit
 
   deploy-http:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-http.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-http.yaml
+    secrets: inherit
 
   deploy-iovation:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-iovation.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-iovation.yaml
+    secrets: inherit

--- a/.github/workflows/deploy-ALL-connectors-1.yaml
+++ b/.github/workflows/deploy-ALL-connectors-1.yaml
@@ -25,182 +25,70 @@ jobs:
 
   deploy-jumio:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-jumio.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-jumio.yaml
+    secrets: inherit
 
   deploy-lexisnexis:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-lexisnexis.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-lexisnexis.yaml
+    secrets: inherit
 
   deploy-mfacontainer:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-mfacontainer.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-mfacontainer.yaml
+    secrets: inherit
 
   deploy-node:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-node.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-node.yaml
+    secrets: inherit
 
   deploy-onfido:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-onfido.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-onfido.yaml
+    secrets: inherit
 
   deploy-openid:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-openid.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-openid.yaml
+    secrets: inherit
 
   deploy-smtp:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-smtp.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-smtp.yaml
+    secrets: inherit
 
   deploy-socure:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-socure.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-socure.yaml
+    secrets: inherit
 
   deploy-totp:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-totp.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-totp.yaml
+    secrets: inherit
 
   deploy-transunion:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-transunion.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-transunion.yaml
+    secrets: inherit
 
   deploy-transunion-tloxp:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-transunion-tloxp.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-transunion-tloxp.yaml
+    secrets: inherit
 
   deploy-userpolicy:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-userpolicy.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-userpolicy.yaml
+    secrets: inherit
 
   deploy-variables:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-variables.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-variables.yaml
+    secrets: inherit
 
   deploy-webhook:
     needs: base-check
-    uses: 18F/identity-idva-orchestration/.github/workflows/deploy-webhook.yaml@main
-    secrets:
-      CF_USERNAME: ${{ secrets.CF_USERNAME }}
-      CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
-      CF_ORG: ${{ secrets.CF_ORG }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SK_SECRETS_DEV: ${{ secrets.SK_SECRETS_DEV }}
-      SK_SECRETS_TEST: ${{ secrets.SK_SECRETS_TEST }}
-      SK_SECRETS_PROD: ${{ secrets.SK_SECRETS_PROD }}
+    uses: ./.github/workflows/deploy-webhook.yaml
+    secrets: inherit

--- a/.github/workflows/deploy-analytics.yaml
+++ b/.github/workflows/deploy-analytics.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-analytics/**'
       - '.github/workflows/deploy-analytics.yaml'
 

--- a/.github/workflows/deploy-analytics.yaml
+++ b/.github/workflows/deploy-analytics.yaml
@@ -6,23 +6,6 @@ name: Deploy analytics
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-api/**'
       - '.github/workflows/deploy-api.yaml'
 

--- a/.github/workflows/deploy-api.yaml
+++ b/.github/workflows/deploy-api.yaml
@@ -6,23 +6,6 @@ name: Deploy api
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-authenticid.yaml
+++ b/.github/workflows/deploy-authenticid.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-authenticid/**'
       - '.github/workflows/deploy-authenticid.yaml'
 

--- a/.github/workflows/deploy-authenticid.yaml
+++ b/.github/workflows/deploy-authenticid.yaml
@@ -6,23 +6,6 @@ name: Deploy authenticid
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-challenge.yaml
+++ b/.github/workflows/deploy-challenge.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-challenge/**'
       - '.github/workflows/deploy-challenge.yaml'
 

--- a/.github/workflows/deploy-challenge.yaml
+++ b/.github/workflows/deploy-challenge.yaml
@@ -6,23 +6,6 @@ name: Deploy challenge
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-credential.yaml
+++ b/.github/workflows/deploy-credential.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-credential/**'
       - '.github/workflows/deploy-credential.yaml'
 

--- a/.github/workflows/deploy-credential.yaml
+++ b/.github/workflows/deploy-credential.yaml
@@ -6,23 +6,6 @@ name: Deploy credential
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-devicepolicy.yaml
+++ b/.github/workflows/deploy-devicepolicy.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-devicepolicy/**'
       - '.github/workflows/deploy-devicepolicy.yaml'
 

--- a/.github/workflows/deploy-devicepolicy.yaml
+++ b/.github/workflows/deploy-devicepolicy.yaml
@@ -6,23 +6,6 @@ name: Deploy devicepolicy
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-events-read.yaml
+++ b/.github/workflows/deploy-events-read.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-events-read/**'
       - '.github/workflows/deploy-events-read.yaml'
 

--- a/.github/workflows/deploy-events-read.yaml
+++ b/.github/workflows/deploy-events-read.yaml
@@ -6,23 +6,6 @@ name: Deploy events read
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-events/**'
       - '.github/workflows/deploy-events.yaml'
 

--- a/.github/workflows/deploy-events.yaml
+++ b/.github/workflows/deploy-events.yaml
@@ -6,23 +6,6 @@ name: Deploy events
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-ews.yaml
+++ b/.github/workflows/deploy-ews.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-ews/**'
       - '.github/workflows/deploy-ews.yaml'
 

--- a/.github/workflows/deploy-ews.yaml
+++ b/.github/workflows/deploy-ews.yaml
@@ -6,23 +6,6 @@ name: Deploy ews
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-ews.yaml
+++ b/.github/workflows/deploy-ews.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-ews/
+          mv caddy Caddyfile ../sk-ews/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-fido.yaml
+++ b/.github/workflows/deploy-fido.yaml
@@ -6,23 +6,6 @@ name: Deploy fido
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-fido.yaml
+++ b/.github/workflows/deploy-fido.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-fido/**'
       - '.github/workflows/deploy-fido.yaml'
 

--- a/.github/workflows/deploy-fido.yaml
+++ b/.github/workflows/deploy-fido.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-fido/
+          mv caddy Caddyfile ../sk-fido/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-flow.yaml
+++ b/.github/workflows/deploy-flow.yaml
@@ -6,23 +6,6 @@ name: Deploy flow
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-flow.yaml
+++ b/.github/workflows/deploy-flow.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-flow/**'
       - '.github/workflows/deploy-flow.yaml'
 

--- a/.github/workflows/deploy-functions.yaml
+++ b/.github/workflows/deploy-functions.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-functions/**'
       - '.github/workflows/deploy-functions.yaml'
 

--- a/.github/workflows/deploy-functions.yaml
+++ b/.github/workflows/deploy-functions.yaml
@@ -6,23 +6,6 @@ name: Deploy functions
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-http.yaml
+++ b/.github/workflows/deploy-http.yaml
@@ -6,23 +6,6 @@ name: Deploy http
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-http.yaml
+++ b/.github/workflows/deploy-http.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-http/**'
       - '.github/workflows/deploy-http.yaml'
 

--- a/.github/workflows/deploy-http.yaml
+++ b/.github/workflows/deploy-http.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-http/
+          mv caddy Caddyfile ../sk-http/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-iovation.yaml
+++ b/.github/workflows/deploy-iovation.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-iovation/**'
       - '.github/workflows/deploy-iovation.yaml'
 

--- a/.github/workflows/deploy-iovation.yaml
+++ b/.github/workflows/deploy-iovation.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-iovation/
+          mv caddy Caddyfile ../sk-iovation/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-iovation.yaml
+++ b/.github/workflows/deploy-iovation.yaml
@@ -6,23 +6,6 @@ name: Deploy iovation
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-jumio.yaml
+++ b/.github/workflows/deploy-jumio.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-jumio/**'
       - '.github/workflows/deploy-jumio.yaml'
 

--- a/.github/workflows/deploy-jumio.yaml
+++ b/.github/workflows/deploy-jumio.yaml
@@ -6,23 +6,6 @@ name: Deploy jumio
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-jumio.yaml
+++ b/.github/workflows/deploy-jumio.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-jumio/
+          mv caddy Caddyfile ../sk-jumio/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-lexisnexis.yaml
+++ b/.github/workflows/deploy-lexisnexis.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-lexisnexis/
+          mv caddy Caddyfile ../sk-lexisnexis/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-lexisnexis.yaml
+++ b/.github/workflows/deploy-lexisnexis.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-lexisnexis/**'
       - '.github/workflows/deploy-lexisnexis.yaml'
 

--- a/.github/workflows/deploy-lexisnexis.yaml
+++ b/.github/workflows/deploy-lexisnexis.yaml
@@ -6,23 +6,6 @@ name: Deploy lexisnexis
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-mfacontainer.yaml
+++ b/.github/workflows/deploy-mfacontainer.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-mfacontainer/**'
       - '.github/workflows/deploy-mfacontainer.yaml'
 

--- a/.github/workflows/deploy-mfacontainer.yaml
+++ b/.github/workflows/deploy-mfacontainer.yaml
@@ -6,23 +6,6 @@ name: Deploy mfacontainer
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-node.yaml
+++ b/.github/workflows/deploy-node.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-node/**'
       - '.github/workflows/deploy-node.yaml'
 

--- a/.github/workflows/deploy-node.yaml
+++ b/.github/workflows/deploy-node.yaml
@@ -6,23 +6,6 @@ name: Deploy node
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-oe.yaml
+++ b/.github/workflows/deploy-oe.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-oe/**'
       - '.github/workflows/deploy-oe.yaml'
 

--- a/.github/workflows/deploy-oe.yaml
+++ b/.github/workflows/deploy-oe.yaml
@@ -6,23 +6,6 @@ name: Deploy oe
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-onfido.yaml
+++ b/.github/workflows/deploy-onfido.yaml
@@ -6,23 +6,6 @@ name: Deploy onfido
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-onfido.yaml
+++ b/.github/workflows/deploy-onfido.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-onfido/**'
       - '.github/workflows/deploy-onfido.yaml'
 

--- a/.github/workflows/deploy-openid.yaml
+++ b/.github/workflows/deploy-openid.yaml
@@ -6,23 +6,6 @@ name: Deploy openid
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-openid.yaml
+++ b/.github/workflows/deploy-openid.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-openid/
+          mv caddy Caddyfile ../sk-openid/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-openid.yaml
+++ b/.github/workflows/deploy-openid.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-openid/**'
       - '.github/workflows/deploy-openid.yaml'
 

--- a/.github/workflows/deploy-portal.yaml
+++ b/.github/workflows/deploy-portal.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-portal/**'
       - '.github/workflows/deploy-portal.yaml'
 

--- a/.github/workflows/deploy-portal.yaml
+++ b/.github/workflows/deploy-portal.yaml
@@ -6,23 +6,6 @@ name: Deploy portal
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-sdk.yaml
+++ b/.github/workflows/deploy-sdk.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-sdk/**'
       - '.github/workflows/deploy-sdk.yaml'
 

--- a/.github/workflows/deploy-sdk.yaml
+++ b/.github/workflows/deploy-sdk.yaml
@@ -6,23 +6,6 @@ name: Deploy sdk
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-smtp.yaml
+++ b/.github/workflows/deploy-smtp.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-smtp/**'
       - '.github/workflows/deploy-smtp.yaml'
 

--- a/.github/workflows/deploy-smtp.yaml
+++ b/.github/workflows/deploy-smtp.yaml
@@ -6,23 +6,6 @@ name: Deploy smtp
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-socure.yaml
+++ b/.github/workflows/deploy-socure.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-socure/**'
       - '.github/workflows/deploy-socure.yaml'
 

--- a/.github/workflows/deploy-socure.yaml
+++ b/.github/workflows/deploy-socure.yaml
@@ -6,23 +6,6 @@ name: Deploy socure
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-totp.yaml
+++ b/.github/workflows/deploy-totp.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-totp/**'
       - '.github/workflows/deploy-totp.yaml'
 

--- a/.github/workflows/deploy-totp.yaml
+++ b/.github/workflows/deploy-totp.yaml
@@ -6,23 +6,6 @@ name: Deploy totp
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-transunion-tloxp.yaml
+++ b/.github/workflows/deploy-transunion-tloxp.yaml
@@ -6,23 +6,6 @@ name: Deploy transunion-tloxp
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-transunion-tloxp.yaml
+++ b/.github/workflows/deploy-transunion-tloxp.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-transunion-tloxp/**'
       - '.github/workflows/deploy-transunion-tloxp.yaml'
 

--- a/.github/workflows/deploy-transunion.yaml
+++ b/.github/workflows/deploy-transunion.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-transunion/**'
       - '.github/workflows/deploy-transunion.yaml'
 

--- a/.github/workflows/deploy-transunion.yaml
+++ b/.github/workflows/deploy-transunion.yaml
@@ -6,23 +6,6 @@ name: Deploy transunion
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-transunion.yaml
+++ b/.github/workflows/deploy-transunion.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-transunion/
+          mv caddy Caddyfile ../sk-transunion/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/deploy-userpolicy.yaml
+++ b/.github/workflows/deploy-userpolicy.yaml
@@ -6,23 +6,6 @@ name: Deploy userpolicy
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-userpolicy.yaml
+++ b/.github/workflows/deploy-userpolicy.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-userpolicy/**'
       - '.github/workflows/deploy-userpolicy.yaml'
 

--- a/.github/workflows/deploy-variables.yaml
+++ b/.github/workflows/deploy-variables.yaml
@@ -6,23 +6,6 @@ name: Deploy variables
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-variables.yaml
+++ b/.github/workflows/deploy-variables.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-variables/**'
       - '.github/workflows/deploy-variables.yaml'
 

--- a/.github/workflows/deploy-webhook.yaml
+++ b/.github/workflows/deploy-webhook.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-webhook/**'
       - '.github/workflows/deploy-webhook.yaml'
 

--- a/.github/workflows/deploy-webhook.yaml
+++ b/.github/workflows/deploy-webhook.yaml
@@ -6,23 +6,6 @@ name: Deploy webhook
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/deploy-webhook.yaml
+++ b/.github/workflows/deploy-webhook.yaml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./proxy
         run: |
           ./install_caddy.sh
-          mv .profile caddy Caddyfile ../sk-webhook/
+          mv caddy Caddyfile ../sk-webhook/
 
       - uses: ./.github/actions/setup
         id: sk-setup

--- a/.github/workflows/run-dbconfigs.yaml
+++ b/.github/workflows/run-dbconfigs.yaml
@@ -1,28 +1,11 @@
 ---
-# This workflow will run the db configs app to initilize postgres db
+# This workflow will run the db configs app to initialize postgres db
 
 name: Run db configs
 
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/run-dbconfigs.yaml
+++ b/.github/workflows/run-dbconfigs.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-dbconfigs/**'
       - '.github/workflows/run-dbconfigs.yaml'
 

--- a/.github/workflows/run-esconfigs.yaml
+++ b/.github/workflows/run-esconfigs.yaml
@@ -1,28 +1,11 @@
 ---
-# This workflow will run the esconfigs app initilize elasticsearch
+# This workflow will run the esconfigs app initialize elasticsearch
 
 name: Run esconfigs
 
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/run-esconfigs.yaml
+++ b/.github/workflows/run-esconfigs.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-esconfigs/**'
       - '.github/workflows/run-esconfigs.yaml'
 

--- a/.github/workflows/run-manifest.yaml
+++ b/.github/workflows/run-manifest.yaml
@@ -6,23 +6,6 @@ name: Run manifest
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      CF_USERNAME:
-        required: true
-      CF_PASSWORD:
-        required: true
-      CF_ORG:
-        required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-      SK_SECRETS_DEV:
-        required: true
-      SK_SECRETS_TEST:
-        required: true
-      SK_SECRETS_PROD:
-        required: true
   push:
     branches:
       - main

--- a/.github/workflows/run-manifest.yaml
+++ b/.github/workflows/run-manifest.yaml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
     paths:
+      - 'common/**'
       - 'sk-manifest/**'
       - '.github/workflows/run-manifest.yaml'
 

--- a/common/.profile
+++ b/common/.profile
@@ -11,3 +11,5 @@ else
 fi
 
 export NODE_OPTIONS="--max_old_space_size=$(( MEMORY_AVAILABLE * 80 / 100 ))"
+
+export NODE_EXTRA_CA_CERTS="/etc/cf-system-certificates/trusted-ca-1.crt"

--- a/common/.profile
+++ b/common/.profile
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 proxy_url=$(echo "$VCAP_SERVICES" | jq -r '."user-provided"?[]? | select(.name == "outbound-proxy") | .credentials.proxy_url')
 
 # Export proxy url variable only if the "proxy_url" variable is not empty
@@ -8,3 +9,5 @@ if [ -n "$proxy_url" ]; then
 else
   echo ".profile script did not find proxy information in VCAP_SERVICES"
 fi
+
+export NODE_OPTIONS="--max_old_space_size=$(( MEMORY_AVAILABLE * 80 / 100 ))"

--- a/sk-ews/manifest.yml
+++ b/sk-ews/manifest.yml
@@ -19,5 +19,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-fido/manifest.yml
+++ b/sk-fido/manifest.yml
@@ -19,5 +19,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-http/manifest.yml
+++ b/sk-http/manifest.yml
@@ -20,5 +20,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-iovation/manifest.yml
+++ b/sk-iovation/manifest.yml
@@ -19,5 +19,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-jumio/manifest.yml
+++ b/sk-jumio/manifest.yml
@@ -19,5 +19,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-lexisnexis/manifest.yml
+++ b/sk-lexisnexis/manifest.yml
@@ -20,5 +20,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-openid/manifest.yml
+++ b/sk-openid/manifest.yml
@@ -19,5 +19,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-transunion/manifest.yml
+++ b/sk-transunion/manifest.yml
@@ -19,5 +19,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090

--- a/sk-webhook/manifest.yml
+++ b/sk-webhook/manifest.yml
@@ -19,5 +19,3 @@ applications:
         command: ./caddy run --config Caddyfile
     env:
       SK_SECRETS: ((SK_SECRETS))
-      HTTP_PROXY: http://localhost:9090
-      HTTPS_PROXY: http://localhost:9090


### PR DESCRIPTION
- Add memory limit option to node apps. This should reduce oom crashes.
- Generalize .profile file by moving it from /caddy to /common
- simplify passing of workflow call secrets using 'secrets: inherit'
- Disable caddy proxy by removing HTTP(S)_PROXY env var